### PR TITLE
wip: Remove dependency and made tile engine usable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,20 +1,4 @@
 [root]
 name = "tile_engine"
 version = "0.1.0"
-dependencies = [
- "xml-rs 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bitflags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "xml-rs"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,3 @@ readme = "README.md"
 repository = "https://github.com/Vinatorul/tileengine-rs"
 homepage = "https://github.com/Vinatorul/tileengine-rs"
 documentation = "https://vinatorul.github.io/tileengine-rs/tile_engine"
-
-[features]
-unstable = []
-
-[dependencies]
-xml-rs = "~0.1"

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,16 +1,17 @@
-use tile;
+use tile::{Tile, TileRect};
 
+// Chunk coordinates in a layer
 pub struct Chunk {
-    x: i32,
-    y: i32,
-    width: i32,
-    height: i32,
-    tiles: Vec<tile::Tile>
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+    tiles: Vec<Tile>,
 }
 
 
 impl Chunk {
-    pub fn new(x: i32, y: i32, h: i32, w: i32) -> Chunk {
+    pub fn new(x: i32, y: i32, w: i32, h: i32) -> Chunk {
         Chunk {
             x: x,
             y: y,
@@ -20,5 +21,15 @@ impl Chunk {
         }
     }
 
-    // pub fn add_tile() 
+    pub fn add_tile(&mut self, x: i32, y: i32, w: i32, h: i32) {
+        self.tiles.push(Tile::new(x - self.x, y - self.y, w, h));
+    } 
+
+    pub fn get_tiles(&self) -> Vec<TileRect> {
+        let mut result = vec![];
+        for tile in self.tiles.iter() {
+            result.push(tile.rect())
+        }
+        result
+    }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,29 @@
-use layer;
+use layer::TilesLayer;
+use std::collections::HashMap;
+use tile::TileRect;
 
-struct TileEngine<'m> {
-    map: &'m str,
-    layers: Vec<layer::TilesLayer>
+pub struct TileEngine {
+    layers: HashMap<i32, TilesLayer>,
+}
+
+impl TileEngine {
+    pub fn new() -> TileEngine {
+        TileEngine {
+            layers: HashMap::<i32, TilesLayer>::new(),
+        }
+    }
+
+    pub fn add_tile(&mut self, x: f64, y: f64, w: i32, h: i32, layer_ind: i32) {
+        if let Some(l) = self.layers.get_mut(&layer_ind) {
+            l.add_tile(x, y, w, h);
+            return;
+        }
+        self.layers.insert(layer_ind, TilesLayer::new());
+        self.add_tile(x, y, w, h, layer_ind);
+    }
+
+    pub fn get_tiles(&self, cam_x: f64, cam_y: f64, cam_w: i32, cam_h: i32, layer_ind: i32) -> Vec<TileRect> {
+        let layer = self.layers.get(&layer_ind).unwrap_or_else(|| {panic!("Layer {} not found", layer_ind)});
+        layer.get_tiles(cam_x, cam_y, cam_w, cam_h)
+    }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,64 @@
-use chunk;
+use chunk::Chunk;
+
+const DEF_CHUNK_WIDTH: i32 = 100;
+const DEF_CHUNK_HEIGHT: i32 = 100;
 
 pub struct TilesLayer {
-    chunks: Vec<chunk::Chunk>
+    x_offset: f64,
+    y_offset: f64,
+    chunks: Vec<Chunk>,
+}
+
+impl TilesLayer {
+    pub fn new() -> TilesLayer {
+        TilesLayer {
+            x_offset: 0.,
+            y_offset: 0.,
+            chunks: Vec::<Chunk>::new(),
+        }
+    }
+
+    #[inline]
+    fn get_rel_x(&self, x: f64) -> i32 {
+        (x - self.x_offset) as i32
+    }
+
+    #[inline]
+    fn get_rel_y(&self, y: f64) -> i32 {
+        (y - self.y_offset) as i32
+    }
+
+    pub fn add_tile(&mut self, x: f64, y: f64, w: i32, h: i32) {
+        let mut chunk_exists = false;
+        let rel_x = self.get_rel_x(x);
+        let rel_y = self.get_rel_y(y); 
+        for chunk in self.chunks.iter_mut() {
+            if (rel_x > chunk.x) && (rel_x < chunk.x + chunk.width) &&
+               (rel_y > chunk.y) && (rel_y < chunk.y + chunk.height) {
+                chunk_exists = true;
+                chunk.add_tile(rel_x, rel_y, w, h);
+                break;
+            }
+        }
+        if !chunk_exists {
+            self.chunks.push(Chunk::new((rel_x/DEF_CHUNK_WIDTH)*DEF_CHUNK_WIDTH, 
+                                        (rel_y/DEF_CHUNK_HEIGHT)*DEF_CHUNK_HEIGHT, 
+                                        DEF_CHUNK_WIDTH, 
+                                        DEF_CHUNK_HEIGHT));
+            self.chunks.last_mut().unwrap().add_tile(rel_x, rel_y, w, h);
+        }
+    }
+
+    pub fn get_tiles(&self, cam_x: f64, cam_y: f64, cam_w: i32, cam_h: i32) -> Vec<::tile::TileRect> {
+        let rel_x = self.get_rel_x(cam_x);
+        let rel_y = self.get_rel_y(cam_y);
+        let mut result = vec![];
+        for chunk in self.chunks.iter() {
+            if (rel_x + cam_w > chunk.x) && (rel_x < chunk.x + chunk.width) &&
+               (rel_y + cam_h > chunk.y) && (rel_y < chunk.y + chunk.height) {
+                result.append(chunk.get_tiles().as_mut());
+            }
+        }
+        result
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 #![crate_name = "tile_engine"]
 #![crate_type = "lib"]
 
-extern crate xml;
-
 mod tile;
 mod core;
-mod reader;
 mod chunk;
 mod layer;
+
+pub use core::TileEngine;
+pub use tile::TileRect;
 
 #[cfg(test)]
 mod tests; 

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,5 +1,6 @@
 pub type TileRect = [i32; 4];
 
+// Tile coodinates in a chunk
 pub struct Tile {
     x: i32, 
     y: i32,


### PR DESCRIPTION
I have removed xml-rs dependency temporarily.
Also added two methods add_tile to add tiles to engine.
And get_tiles to get all visible tiles in square.
